### PR TITLE
fix: pin the footer to the bottom and give it room on mobile

### DIFF
--- a/src/components/footer.astro
+++ b/src/components/footer.astro
@@ -3,7 +3,7 @@ import Logo from "../components/logo.astro";
 ---
 
 <section
-  class="text-gray-700 bg-white border-t sm:mt-20 dark:bg-neutral-950 border-neutral-200 dark:border-neutral-800"
+  class="text-gray-700 bg-white border-t mt-12 sm:mt-20 dark:bg-neutral-950 border-neutral-200 dark:border-neutral-800"
 >
   <div
     class="container flex flex-col items-center py-8 mx-auto px-7 max-w-7xl sm:flex-row"

--- a/src/layouts/main.astro
+++ b/src/layouts/main.astro
@@ -44,10 +44,12 @@ const hasPosts = (await getCollection("posts")).length > 0;
       )
     }
   </head>
-  <body class="antialiased bg-white dark:bg-neutral-950">
+  <body class="flex flex-col antialiased bg-white dark:bg-neutral-950 min-h-dvh">
     <SquareLines />
     <Header />
-    <slot />
+    <main class="flex-1">
+      <slot />
+    </main>
     <Footer />
     <script src="../assets/js/main.js" />
     {


### PR DESCRIPTION
Two long-standing layout bugs, both on the footer. Neither came from the Astro 7
/ Tailwind 4 upgrade in #163 — a pixel diff of the mobile screenshots before and
after that upgrade is identical below y=151.

## 1. The mobile divider touched the button

The footer's only top margin was `sm:mt-20`, which does nothing below 640px. On
the homepage at 375px the "Connect with me on Linkedin" button ended at y=495
and the footer's `border-t` started at y=495 — a **0px** gap.

Adds `mt-12`, so mobile gets 48px and `sm:` and up keep the existing 80px.

## 2. The footer floated mid-page on short pages

It stopped wherever the content ended instead of at the bottom of the viewport,
leaving empty white beneath it:

| Viewport | Dead space below footer | After |
| --- | --- | --- |
| 375 x 812 | 156px | 0px |
| 1728 x 1117 | 246px | 0px |

`<body>` becomes a full-height flex column (`min-h-dvh flex flex-col`) and the
page slot is wrapped in `<main class="flex-1">`, so `main` absorbs the leftover
height and pushes the footer down. This is the standard sticky-footer pattern —
it does **not** make the footer `fixed`, so on a long page it still scrolls away
with the content.

The `<main>` wrapper also gives every page a landmark it didn't have.

## Verification

- Homepage: 0px dead space below the footer at 375, 1280 and 1728 wide, and no
  scrollbar is introduced at any of them.
- `/about` (3409px tall) still scrolls normally, footer flowing after the
  content at y=3248 — the pin correctly does not engage.
- No horizontal overflow at 375px on either page
  (`document.documentElement.scrollWidth === 375`).
- `pnpm run check`, `pnpm run build` and `prek run --all-files` all pass.